### PR TITLE
fix: Correct GitHub Package Publishing | feat: Set Version automatically from GitHub reference name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ jobs:
     name: Build and Publish
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+      
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -20,13 +24,14 @@ jobs:
           java-version: 17
 
       - name: Configure Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       
       - name: Grant execute permission for Gradle wrapper
         run: chmod +x gradlew
       
       - name: Publish package
+        run: ./gradlew publish
         env:
           USERNAME: ${{ secrets.GITHUB_ACTOR }}
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew publish
+          API_VERSION: ${{ github.ref_name }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Advik-B/Wattpad-API.Jar")
+            url = uri("https://maven.pkg.github.com/Advik-B/Wattpad-API.jar")
             credentials {
                 username = (project.findProperty("gpr.user") ?: System.getenv("USERNAME")) as String?
                 password = (project.findProperty("gpr.token") ?: System.getenv("TOKEN")) as String?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Advik-B/Wattpad-API.jar")
+            url = uri("https://maven.pkg.github.com/Advik-B/Wattpad-API-Java")
             credentials {
                 username = (project.findProperty("gpr.user") ?: System.getenv("USERNAME")) as String?
                 password = (project.findProperty("gpr.token") ?: System.getenv("TOKEN")) as String?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,21 +4,11 @@ plugins {
     id("maven-publish")
 }
 
-group = "io.github.advik-b"
-version = "1.1"
+group = "dev.advik"
+version = System.getenv("API_VERSION") ?: "1.1"
 
 repositories {
     mavenCentral()
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Advik-B/Wattpad-API.jar")
-            credentials {
-                username = (project.findProperty("gpr.user") ?: System.getenv("USERNAME")) as String?
-                password = (project.findProperty("gpr.token") ?: System.getenv("TOKEN")) as String?
-            }
-        }
-    }
 }
 
 dependencies {
@@ -73,16 +63,14 @@ tasks.build {
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
+            artifactId = project.name.lowercase()
             from(components["java"])
-
-            groupId = group as String
-            version = version
         }
     }
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Advik-B/Wattpad-API.jar")
+            url = uri("https://maven.pkg.github.com/Advik-B/Wattpad-API.Jar")
             credentials {
                 username = (project.findProperty("gpr.user") ?: System.getenv("USERNAME")) as String?
                 password = (project.findProperty("gpr.token") ?: System.getenv("TOKEN")) as String?


### PR DESCRIPTION
- Corrects GitHub Package publishing, removes unnecessary maven repository, correct package name, etc.
- Allows setting version number with "API_VERSION" environment variable (sets automatically in release action workflow), or manually.

## Summary by Sourcery

Fix GitHub Package publishing configuration and automate versioning from GitHub ref tags while updating the CI workflow for permissions and tooling versions.

New Features:
- Automate project versioning using API_VERSION environment variable sourced from GitHub reference names.

Bug Fixes:
- Correct the GitHub Packages repository URL and remove redundant nested Maven repository declarations.

Enhancements:
- Change project group ID to 'dev.advik' and normalize the artifactId to the lowercase project name.

CI:
- Add contents: read and packages: write permissions and pass API_VERSION in the publish workflow.
- Upgrade the Gradle setup action to v4.